### PR TITLE
fix: use RELEASE_TOKEN to bypass branch protection on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
## Summary
- Swap `GITHUB_TOKEN` for `RELEASE_TOKEN` (fine-grained PAT) in the checkout step so `git push --follow-tags` can bypass the branch protection rule on `main`

## Test plan
- [ ] Trigger **Release** workflow on this branch with **dry run = true** first to validate
- [ ] Merge and trigger with **dry run = false** for a real release

🤖 Generated with [Claude Code](https://claude.com/claude-code)