### PR TITLE
feat: generate coverage badge on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Generate coverage badge
+        run: |
+          uv run pytest --cov=fusion --cov-report=xml -q
+          uv run coverage-badge -o coverage.svg -f
+
       - name: Bump version
         id: bump
         run: |
@@ -58,6 +63,12 @@ jobs:
             uv run cz bump --increment ${{ inputs.bump }} --yes --changelog $DRY_RUN
           fi
           echo "version=$(uv run cz version --project)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit coverage badge
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          git add coverage.svg
+          git diff --cached --quiet || git commit -m "chore: update coverage badge"
 
       - name: Push tag and changelog
         if: ${{ inputs.dry_run != true }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 > A modern, async-first ASGI web framework for Python with type-safe dependency injection.
 
-[![Version](https://img.shields.io/badge/version-0.4.1-blue)](https://github.com/okanakbulut/fusion)
-[![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org)
+[![PyPI](https://img.shields.io/pypi/v/fusion)](https://pypi.org/project/fusion/)
+[![Python](https://img.shields.io/badge/python-3.12%20|%203.13%20|%203.14-blue)](https://www.python.org)
+[![CI](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml)
+[![Coverage](./coverage.svg)](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ Homepage = "https://github.com/okanakbulut/fusion"
 [project.optional-dependencies]
 dev = [
     "coverage[toml]>=6.5",
+    "coverage-badge>=1.1",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,19 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage-badge"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/8f/e92b0a010c76b0da82709838b3f3ae9aec638d0c44dbfb1186a5751f5d2e/coverage_badge-1.1.2.tar.gz", hash = "sha256:fe7ed58a3b72dad85a553b64a99e963dea3847dcd0b8ddd2b38a00333618642c", size = 6335, upload-time = "2024-08-02T23:34:08.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/3d/5642a1a06191b2e1e0f87a2e824e6d3eb7c32c589a68ed4d1dcbd3324d63/coverage_badge-1.1.2-py2.py3-none-any.whl", hash = "sha256:d8413ce51c91043a1692b943616b450868cbeeb0ea6a0c54a32f8318c9c96ff7", size = 6493, upload-time = "2024-08-02T23:34:07.063Z" },
+]
+
+[[package]]
 name = "decli"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -201,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "fusion"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgspec" },
@@ -212,6 +225,7 @@ dependencies = [
 dev = [
     { name = "commitizen" },
     { name = "coverage" },
+    { name = "coverage-badge" },
     { name = "httpx" },
     { name = "ipython" },
     { name = "pre-commit" },
@@ -227,6 +241,7 @@ dev = [
 requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = "==4.13.10" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=6.5" },
+    { name = "coverage-badge", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "msgspec", specifier = ">=0.21.1" },
@@ -668,6 +683,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `coverage-badge` to dev dependencies
- Release workflow runs tests, generates `coverage.svg`, commits it alongside the version bump
- README references `coverage.svg` directly — no external service needed
- Revert Codecov step in `ci.yml` (not needed)

## How it works
On each release, the workflow runs:
1. `pytest --cov` → produces coverage data
2. `coverage-badge -o coverage.svg -f` → generates the SVG
3. `cz bump` → commits `pyproject.toml` + `CHANGELOG.md`
4. Commits `coverage.svg` separately
5. Pushes everything with `--follow-tags`

## Test plan
- [ ] Trigger Release workflow with **dry run = true** to validate tests + badge generation pass
- [ ] Merge and do a real release to confirm `coverage.svg` appears in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)