### PR TITLE
fix: replace coverage-badge with inline script for Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,28 @@ jobs:
       - name: Generate coverage badge
         run: |
           uv run pytest --cov=fusion --cov-report=xml -q
-          uv run coverage-badge -o coverage.svg -f
+          python - <<'EOF'
+          import xml.etree.ElementTree as ET
+          pct = round(float(ET.parse("coverage.xml").getroot().get("line-rate")) * 100, 1)
+          color = "brightgreen" if pct >= 90 else "yellow" if pct >= 75 else "red"
+          label, value = "coverage", f"{pct}%"
+          lw, vw = 62, len(value) * 7 + 10
+          w = lw + vw
+          svg = f"""<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20">
+            <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+            <rect rx="3" width="{w}" height="20" fill="#555"/>
+            <rect rx="3" x="{lw}" width="{vw}" height="20" fill="{color}"/>
+            <rect rx="3" width="{w}" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="{lw//2}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+              <text x="{lw//2}" y="14">{label}</text>
+              <text x="{lw + vw//2}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
+              <text x="{lw + vw//2}" y="14">{value}</text>
+            </g>
+          </svg>"""
+          open("coverage.svg", "w").write(svg)
+          print(f"Coverage badge generated: {pct}%")
+          EOF
 
       - name: Bump version
         id: bump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ Homepage = "https://github.com/okanakbulut/fusion"
 [project.optional-dependencies]
 dev = [
     "coverage[toml]>=6.5",
-    "coverage-badge>=1.1",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/uv.lock
+++ b/uv.lock
@@ -143,19 +143,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coverage-badge"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/8f/e92b0a010c76b0da82709838b3f3ae9aec638d0c44dbfb1186a5751f5d2e/coverage_badge-1.1.2.tar.gz", hash = "sha256:fe7ed58a3b72dad85a553b64a99e963dea3847dcd0b8ddd2b38a00333618642c", size = 6335, upload-time = "2024-08-02T23:34:08.58Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/3d/5642a1a06191b2e1e0f87a2e824e6d3eb7c32c589a68ed4d1dcbd3324d63/coverage_badge-1.1.2-py2.py3-none-any.whl", hash = "sha256:d8413ce51c91043a1692b943616b450868cbeeb0ea6a0c54a32f8318c9c96ff7", size = 6493, upload-time = "2024-08-02T23:34:07.063Z" },
-]
-
-[[package]]
 name = "decli"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -225,7 +212,6 @@ dependencies = [
 dev = [
     { name = "commitizen" },
     { name = "coverage" },
-    { name = "coverage-badge" },
     { name = "httpx" },
     { name = "ipython" },
     { name = "pre-commit" },
@@ -241,7 +227,6 @@ dev = [
 requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = "==4.13.10" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=6.5" },
-    { name = "coverage-badge", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "msgspec", specifier = ">=0.21.1" },
@@ -683,15 +668,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Remove `coverage-badge` dep (uses deprecated `pkg_resources`, broken on Python 3.14)
- Replace with an inline Python script that reads `coverage.xml` using stdlib only
- No external dependencies, works on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)