### PR TITLE
fix: skip --changelog when previous tag is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,16 @@ jobs:
         id: bump
         run: |
           DRY_RUN=${{ inputs.dry_run == true && '--dry-run' || '' }}
-          if [ "${{ inputs.bump }}" = "auto" ]; then
-            uv run cz bump --yes --changelog $DRY_RUN
+          PREV_TAG="v$(uv run cz version --project)"
+          if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            CHANGELOG="--changelog"
           else
-            uv run cz bump --increment ${{ inputs.bump }} --yes --changelog $DRY_RUN
+            CHANGELOG=""
+          fi
+          if [ "${{ inputs.bump }}" = "auto" ]; then
+            uv run cz bump --yes $CHANGELOG $DRY_RUN
+          else
+            uv run cz bump --increment ${{ inputs.bump }} --yes $CHANGELOG $DRY_RUN
           fi
           echo "version=$(uv run cz version --project)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Check if the previous version tag exists before passing `--changelog` to `cz bump`
- Prevents exit code 16 ("No tag found to do an incremental changelog") when a tag was never pushed

## Root cause
A prior workflow run failed after `cz bump` created the tag but before `git push --follow-tags` — the commit reached `main` via PR merge but the tag was never pushed. Fixed separately by manually creating the `v0.5.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)