### PR TITLE
fix: use absolute URL for coverage badge so it renders on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI](https://img.shields.io/pypi/v/fusion)](https://pypi.org/project/fusion/)
 [![Python](https://img.shields.io/badge/python-3.12%20|%203.13%20|%203.14-blue)](https://www.python.org)
 [![CI](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml/badge.svg)](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml)
-[![Coverage](./coverage.svg)](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/okanakbulut/fusion/main/coverage.svg)](https://github.com/okanakbulut/fusion/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
 
 ---


### PR DESCRIPTION
## Summary
- Replace `./coverage.svg` (relative path) with `https://raw.githubusercontent.com/okanakbulut/fusion/main/coverage.svg`
- Relative paths don't resolve on PyPI — absolute raw GitHub URLs work on both GitHub and PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)