### PR TITLE
feat: structured RFC-9457 validation errors with per-field details

### DIFF
--- a/src/fusion/__init__.py
+++ b/src/fusion/__init__.py
@@ -18,6 +18,6 @@ from .responses import (
     Problem,
     Response,
     Unauthorized,
-    ValidationError,
+    ValidationProblem,
 )
 from .route import Delete, Get, Head, Options, Patch, Post, Put, Route

--- a/src/fusion/context.py
+++ b/src/fusion/context.py
@@ -4,6 +4,7 @@ import typing
 from urllib.parse import parse_qsl
 
 from ._utils import cached_property
+from .exceptions import ValidationException
 from .types import Receive, Scope, Send
 
 context: contextvars.ContextVar[Context] = contextvars.ContextVar("context")
@@ -79,8 +80,8 @@ class Context(contextlib.AsyncExitStack):
                 if chunk:
                     total += len(chunk)
                     if total > MAX_BODY_SIZE:
-                        raise ValueError(
-                            f"Request body exceeds maximum size of {MAX_BODY_SIZE} bytes"
+                        raise ValidationException(
+                            detail=f"Request body exceeds maximum size of {MAX_BODY_SIZE} bytes"
                         )
                     chunks.append(chunk)
                 if not message.get("more_body", False):

--- a/src/fusion/exceptions.py
+++ b/src/fusion/exceptions.py
@@ -1,0 +1,7 @@
+from .responses import FieldError
+
+
+class ValidationException(Exception):
+    def __init__(self, errors: list[FieldError] | None = None, detail: str | None = None) -> None:
+        self.errors = errors
+        self.detail = detail

--- a/src/fusion/request.py
+++ b/src/fusion/request.py
@@ -1,6 +1,12 @@
+import typing
+
+import msgspec
+
 from .annotations import Cookie, Header, PathParam, QueryParam, RequestBody
 from .context import context
+from .exceptions import ValidationException
 from .injectable import Injectable
+from .responses import FieldError
 from .types import Receive, Scope, Send
 
 
@@ -60,3 +66,29 @@ class Request(Injectable):
 
     async def body(self) -> bytes:
         return await context.get().body()
+
+    @classmethod
+    async def instance(cls) -> typing.Self:
+        params: dict[str, typing.Any] = {}
+        errors: list[FieldError] = []
+
+        for resolver in cls.__resolvers__.values():
+            try:
+                name, value = await resolver.resolve()
+                params[name] = value
+            except ValidationException as exc:
+                if exc.errors:
+                    errors.extend(exc.errors)
+                elif exc.detail:
+                    location = getattr(resolver, "location", "unknown")
+                    errors.append(
+                        FieldError(field=resolver.name, location=location, message=exc.detail)
+                    )
+            except msgspec.ValidationError as exc:
+                location = getattr(resolver, "location", "unknown")
+                errors.append(FieldError(field=resolver.name, location=location, message=str(exc)))
+
+        if errors:
+            raise ValidationException(errors=errors)
+
+        return cls(**params)

--- a/src/fusion/resolvers.py
+++ b/src/fusion/resolvers.py
@@ -5,7 +5,9 @@ from contextlib import AbstractAsyncContextManager
 import msgspec
 
 from .context import Context, context
+from .exceptions import ValidationException
 from .object import Object
+from .responses import FieldError
 
 T = typing.TypeVar("T")
 type Constructor[T] = typing.Callable[[], typing.Awaitable[T] | AbstractAsyncContextManager[T]]
@@ -62,6 +64,8 @@ class FactoryResolver(Resolver):
 class QueryParamResolver(Resolver):
     """Resolver for query parameters."""
 
+    location: typing.ClassVar[str] = "query"
+
     async def resolve(self) -> tuple[str, typing.Any]:
         """Resolve the query parameter from the request context."""
         value = self.context.query_params.get(self.name, None)
@@ -71,37 +75,87 @@ class QueryParamResolver(Resolver):
 class PathParamResolver(Resolver):
     """Resolver for path parameters."""
 
+    location: typing.ClassVar[str] = "path"
+
     async def resolve(self) -> tuple[str, typing.Any]:
         """Resolve the path parameter from the request context."""
         value = self.context.path_params.get(self.name, None)
-        if value is not None:
-            value = msgspec.convert(value, self.typ, strict=False)
-        return self.name, value
+        return self.name, msgspec.convert(value, self.typ, strict=False)
 
 
 class RequestBodyResolver(Resolver):
     """Resolver for request body parameters."""
 
+    location: typing.ClassVar[str] = "body"
+
     async def resolve(self) -> tuple[str, typing.Any]:
         """Resolve the request body from the request context."""
         body = await self.context.body()
-        value = msgspec.json.decode(body, type=self.typ, strict=True)
-        return self.name, value
+
+        if not (isinstance(self.typ, type) and issubclass(self.typ, msgspec.Struct)):
+            return self.name, msgspec.json.decode(body, type=self.typ, strict=True)
+
+        try:
+            return self.name, msgspec.json.decode(body, type=self.typ, strict=True)
+        except msgspec.DecodeError as exc:
+            raise ValidationException(detail=str(exc)) from exc
+        except msgspec.ValidationError:
+            pass
+
+        try:
+            raw = msgspec.json.decode(body)
+        except msgspec.DecodeError as exc:
+            raise ValidationException(detail=str(exc)) from exc
+
+        if not isinstance(raw, dict):
+            raise ValidationException(detail="Request body must be a JSON object")
+
+        field_errors: list[FieldError] = []
+        params: dict[str, typing.Any] = {}
+
+        for field in msgspec.structs.fields(self.typ):
+            if field.encode_name in raw:
+                try:
+                    params[field.name] = msgspec.convert(
+                        raw[field.encode_name], field.type, strict=False
+                    )
+                except msgspec.ValidationError as exc:
+                    field_errors.append(
+                        FieldError(field=field.name, location="body", message=str(exc))
+                    )
+            elif field.default is not msgspec.NODEFAULT:
+                params[field.name] = field.default
+            elif field.default_factory is not msgspec.NODEFAULT:
+                params[field.name] = field.default_factory()
+            else:
+                try:
+                    msgspec.convert(None, field.type, strict=False)
+                except msgspec.ValidationError as exc:
+                    field_errors.append(
+                        FieldError(field=field.name, location="body", message=str(exc))
+                    )
+
+        if field_errors:
+            raise ValidationException(errors=field_errors)
+
+        return self.name, self.typ(**params)
 
 
 class HeaderResolver(Resolver):
     """Resolver for header."""
 
+    location: typing.ClassVar[str] = "header"
+
     async def resolve(self) -> tuple[str, typing.Any]:
         """Resolve the header parameter from the request context."""
         value = self.context.headers.get(self.name, None)
-        if value is None:
-            raise ValueError(f"Missing header '{self.name}'")
         return self.name, msgspec.convert(value, self.typ, strict=False)
 
 
 class CookieResolver(Resolver):
     """Resolver for cookie."""
+
+    location: typing.ClassVar[str] = "cookie"
 
     async def resolve(self) -> tuple[str, typing.Any]:
         """Resolve the cookie parameter from the request context."""
@@ -110,6 +164,4 @@ class CookieResolver(Resolver):
             for key, value in self.context.cookies.items()
         }
         value = cookies.get(self.name, None)
-        if value is not None:
-            value = msgspec.convert(value, self.typ, strict=False)
-        return self.name, value
+        return self.name, msgspec.convert(value, self.typ, strict=False)

--- a/src/fusion/resolvers.py
+++ b/src/fusion/resolvers.py
@@ -97,10 +97,10 @@ class RequestBodyResolver(Resolver):
 
         try:
             return self.name, msgspec.json.decode(body, type=self.typ, strict=True)
-        except msgspec.DecodeError as exc:
-            raise ValidationException(detail=str(exc)) from exc
         except msgspec.ValidationError:
             pass
+        except msgspec.DecodeError as exc:
+            raise ValidationException(detail=str(exc)) from exc
 
         try:
             raw = msgspec.json.decode(body)

--- a/src/fusion/responses.py
+++ b/src/fusion/responses.py
@@ -108,10 +108,11 @@ class InternalServerError(Problem):
 
 class FieldError(Object):
     field: str
+    location: str
     message: str
 
 
-class ValidationError(BadRequest):
+class ValidationProblem(BadRequest):
     errors: list[FieldError] | None = None
 
     @property

--- a/src/fusion/router.py
+++ b/src/fusion/router.py
@@ -4,8 +4,15 @@ import typing
 import msgspec
 
 from .context import Context
+from .exceptions import ValidationException
 from .protocols import HttpRequest
-from .responses import BadRequest, InternalServerError, MethodNotAllowed, NotFound
+from .responses import (
+    BadRequest,
+    InternalServerError,
+    MethodNotAllowed,
+    NotFound,
+    ValidationProblem,
+)
 from .route import Route
 from .types import Method, Receive, Scope, Send
 
@@ -118,8 +125,8 @@ class TreeRouter:
                     request_class = route.get_request_class()
                     request = await request_class.instance()
                     response = await route.handle(request)
-                except (ValueError, msgspec.ValidationError) as exc:
-                    response = BadRequest(detail=str(exc))
+                except ValidationException as exc:
+                    response = ValidationProblem(errors=exc.errors, detail=exc.detail)
                 except Exception:
                     # TODO: log the exception here
                     response = InternalServerError()

--- a/tests/fusion/test_handler.py
+++ b/tests/fusion/test_handler.py
@@ -5,7 +5,7 @@ import pytest
 
 from fusion import Fusion, Handler, Object, Request, Response, Route
 from fusion.protocols import HttpHandler
-from fusion.responses import BadRequest, FieldError, NotFound, ValidationError
+from fusion.responses import BadRequest, FieldError, NotFound, ValidationProblem
 from fusion.types import Receive, Scope, Send
 
 
@@ -183,12 +183,12 @@ async def test_method_not_allowed_returns_problem_json():
 @pytest.mark.asyncio
 async def test_validation_error_with_field_errors():
     class CreateHandler(Handler):
-        async def handle(self, request: Request) -> ValidationError | Response[Object]:
-            return ValidationError(
+        async def handle(self, request: Request) -> ValidationProblem | Response[Object]:
+            return ValidationProblem(
                 detail="Validation failed",
                 errors=[
-                    FieldError(field="email", message="invalid format"),
-                    FieldError(field="name", message="required"),
+                    FieldError(field="email", location="body", message="invalid format"),
+                    FieldError(field="name", location="body", message="required"),
                 ],
             )
 
@@ -210,8 +210,8 @@ async def test_validation_error_with_field_errors():
     assert body["status"] == 400
     assert body["detail"] == "Validation failed"
     assert body["errors"] == [
-        {"field": "email", "message": "invalid format"},
-        {"field": "name", "message": "required"},
+        {"field": "email", "location": "body", "message": "invalid format"},
+        {"field": "name", "location": "body", "message": "required"},
     ]
 
 

--- a/tests/fusion/test_handler.py
+++ b/tests/fusion/test_handler.py
@@ -26,6 +26,14 @@ class MyResponse(Object):
         )
 
 
+def test_handler_get_request_class():
+    class MyHandler(Handler):
+        async def handle(self, request: Request) -> Response:
+            return Response(None)
+
+    assert MyHandler().get_request_class() is Request
+
+
 def test_handler_protocol_compliance():
     class BaseRequest(Object):
         @classmethod

--- a/tests/fusion/test_headers.py
+++ b/tests/fusion/test_headers.py
@@ -1,6 +1,5 @@
-import pytest
-
 import msgspec
+import pytest
 
 from fusion import Cookie, Fusion, Handler, Header, Object, Request, Response, Route
 from fusion.testing import TestClient

--- a/tests/fusion/test_headers.py
+++ b/tests/fusion/test_headers.py
@@ -1,6 +1,8 @@
 import pytest
 
-from fusion import Cookie, Fusion, Handler, Header, Injectable, Object, Request, Response, Route
+import msgspec
+
+from fusion import Cookie, Fusion, Handler, Header, Object, Request, Response, Route
 from fusion.testing import TestClient
 
 
@@ -10,20 +12,13 @@ async def test_headers():
         authorization: str
         user_id: int
 
-    class AuthInput(Injectable):
+    class AuthRequest(Request, kw_only=True):
         authorization: Header[str]
         user_id: Header[int]
 
     class AuthorizationHandler(Handler):
-        auth: AuthInput
-
-        async def handle(
-            self,
-            request: Request,
-        ) -> Response[Output]:
-            return Response(
-                Output(authorization=self.auth.authorization, user_id=self.auth.user_id)
-            )
+        async def handle(self, request: AuthRequest) -> Response[Output]:
+            return Response(Output(authorization=request.authorization, user_id=request.user_id))
 
     app = Fusion(routes=[Route(path="/auth", methods=["GET"], handler=AuthorizationHandler)])
 
@@ -37,21 +32,17 @@ async def test_headers():
 
 @pytest.mark.asyncio
 async def test_headers_with_missing_header():
-    class Input(Injectable):
-        authorization: Header[str]
-        user_id: Header[int]
-
     class Output(Object):
         authorization: str
         user_id: int
 
-    class AuthorizationHandler(Handler):
-        input: Input
+    class AuthRequest(Request, kw_only=True):
+        authorization: Header[str]
+        user_id: Header[int]
 
-        async def handle(self, request: Request) -> Response[Output]:
-            return Response(
-                Output(authorization=self.input.authorization, user_id=self.input.user_id)
-            )
+    class AuthorizationHandler(Handler):
+        async def handle(self, request: AuthRequest) -> Response[Output]:
+            return Response(Output(authorization=request.authorization, user_id=request.user_id))
 
     app = Fusion(routes=[Route(path="/auth", methods=["GET"], handler=AuthorizationHandler)])
 
@@ -61,22 +52,39 @@ async def test_headers_with_missing_header():
         assert response.headers["content-type"] == "application/problem+json"
         body = response.json()
         assert body["status"] == 400
-        assert "authorization" in body["detail"].lower()
+        errors = body["errors"]
+        assert any(e["field"] == "authorization" for e in errors)
+        assert any(e["field"] == "user_id" for e in errors)
+
+
+@pytest.mark.asyncio
+async def test_optional_header_resolves_to_none_when_missing():
+    class AuthRequest(Request, kw_only=True):
+        authorization: Header[str | None] = None
+
+    class AuthorizationHandler(Handler):
+        async def handle(self, request: AuthRequest) -> Response:
+            return Response(content={"auth": request.authorization})
+
+    app = Fusion(routes=[Route(path="/auth", methods=["GET"], handler=AuthorizationHandler)])
+
+    async with TestClient(app) as client:
+        response = await client.get("/auth")
+        assert response.status_code == 200
+        assert response.json() == {"auth": None}
 
 
 @pytest.mark.asyncio
 async def test_cookie_resolver():
-    class Input(Injectable):
+    class SessionRequest(Request, kw_only=True):
         session: Cookie[str]
 
     class Output(Object):
         session: str
 
     class CookieHandler(Handler):
-        inp: Input
-
-        async def handle(self, request: Request) -> Response[Output]:
-            return Response(Output(session=self.inp.session))
+        async def handle(self, request: SessionRequest) -> Response[Output]:
+            return Response(Output(session=request.session))
 
     app = Fusion(routes=[Route(path="/session", methods=["GET"], handler=CookieHandler)])
 
@@ -105,10 +113,9 @@ async def test_path_param_resolver_with_none_value():
         "path": "/",
         "query_string": b"",
         "headers": [],
-        "path_params": {},  # empty — no id param
+        "path_params": {},
     }
     async with Context(scope, receive, send):
         resolver = PathParamResolver(name="id", typ=int)
-        name, value = await resolver.resolve()
-    assert name == "id"
-    assert value is None
+        with pytest.raises(msgspec.ValidationError):
+            await resolver.resolve()

--- a/tests/fusion/test_request_body.py
+++ b/tests/fusion/test_request_body.py
@@ -1,9 +1,11 @@
 from typing import TypeVar
 
 import httpx
+import msgspec
 import pytest
 
 from fusion import Fusion, Handler, Injectable, Object, Request, RequestBody, Response, Route
+from fusion.testing import TestClient
 
 T = TypeVar("T")
 
@@ -41,3 +43,174 @@ async def test_request_body():
         )
         assert response.status_code == 200
         assert response.json() == {"id": 1, "name": "John Doe", "email": "john@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_struct_body_field_type_error_returns_per_field_errors():
+    class Payload(msgspec.Struct):
+        name: str
+        age: int
+
+    class CreateRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class CreateHandler(Handler):
+        async def handle(self, request: CreateRequest) -> Response:
+            return Response(content={"name": request.body.name, "age": request.body.age})
+
+    app = Fusion(routes=[Route("/create", methods=["POST"], handler=CreateHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post("/create", json={"name": "Alice", "age": "not-a-number"})
+
+    assert r.status_code == 400
+    body = r.json()
+    assert "errors" in body
+    assert any(e["field"] == "age" and e["location"] == "body" for e in body["errors"])
+
+
+@pytest.mark.asyncio
+async def test_struct_body_missing_required_field_returns_field_error():
+    class Payload(msgspec.Struct):
+        name: str
+        age: int
+
+    class CreateRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class CreateHandler(Handler):
+        async def handle(self, request: CreateRequest) -> Response:
+            return Response(content={"name": request.body.name})
+
+    app = Fusion(routes=[Route("/create", methods=["POST"], handler=CreateHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post("/create", json={})
+
+    assert r.status_code == 400
+    body = r.json()
+    errors = body["errors"]
+    assert any(e["field"] == "name" for e in errors)
+    assert any(e["field"] == "age" for e in errors)
+
+
+@pytest.mark.asyncio
+async def test_struct_body_non_dict_json_returns_400():
+    class Payload(msgspec.Struct):
+        x: int
+
+    class PayloadRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class PayloadHandler(Handler):
+        async def handle(self, request: PayloadRequest) -> Response:
+            return Response(content={"x": request.body.x})
+
+    app = Fusion(routes=[Route("/payload", methods=["POST"], handler=PayloadHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post(
+            "/payload",
+            content=b"[1, 2, 3]",
+            headers={"content-type": "application/json"},
+        )
+
+    assert r.status_code == 400
+    body = r.json()
+    messages = [e["message"] for e in body.get("errors", [])] + [body.get("detail", "") or ""]
+    assert any("must be a JSON object" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_struct_body_field_with_default_uses_default_when_missing():
+    class Payload(msgspec.Struct):
+        name: str = "default"
+        age: int = 0
+
+    class PayloadRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class PayloadHandler(Handler):
+        async def handle(self, request: PayloadRequest) -> Response:
+            return Response(content={"name": request.body.name, "age": request.body.age})
+
+    app = Fusion(routes=[Route("/payload", methods=["POST"], handler=PayloadHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post("/payload", json={"name": "Alice", "age": "not-a-number"})
+
+    assert r.status_code == 400
+    assert any(e["field"] == "age" for e in r.json()["errors"])
+
+
+@pytest.mark.asyncio
+async def test_struct_body_field_with_default_factory_uses_factory_when_missing():
+    class Payload(msgspec.Struct):
+        age: int
+        tags: list[str] = msgspec.field(default_factory=list)
+
+    class PayloadRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class PayloadHandler(Handler):
+        async def handle(self, request: PayloadRequest) -> Response:
+            return Response(content={"age": request.body.age, "tags": request.body.tags})
+
+    app = Fusion(routes=[Route("/payload", methods=["POST"], handler=PayloadHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post("/payload", json={"age": "not-a-number"})
+
+    assert r.status_code == 400
+    assert any(e["field"] == "age" for e in r.json()["errors"])
+
+
+@pytest.mark.asyncio
+async def test_struct_body_coercion_succeeds_via_two_pass():
+    class Payload(msgspec.Struct):
+        count: int
+
+    class PayloadRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class PayloadHandler(Handler):
+        async def handle(self, request: PayloadRequest) -> Response:
+            return Response(content={"count": request.body.count})
+
+    app = Fusion(routes=[Route("/payload", methods=["POST"], handler=PayloadHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post(
+            "/payload",
+            content=b'{"count": "5"}',
+            headers={"content-type": "application/json"},
+        )
+
+    assert r.status_code == 200
+    assert r.json() == {"count": 5}
+
+
+@pytest.mark.asyncio
+async def test_request_body_size_exceeded_detail_collected_as_field_error():
+    from fusion.context import MAX_BODY_SIZE
+
+    class Payload(msgspec.Struct):
+        data: str
+
+    class BigRequest(Request, kw_only=True):
+        body: RequestBody[Payload]
+
+    class BigHandler(Handler):
+        async def handle(self, request: BigRequest) -> Response:
+            return Response(content={"data": request.body.data})
+
+    app = Fusion(routes=[Route("/big", methods=["POST"], handler=BigHandler)])
+
+    async with TestClient(app) as c:
+        r = await c.post(
+            "/big",
+            content=b"x" * (MAX_BODY_SIZE + 1),
+            headers={"content-type": "application/json"},
+        )
+
+    assert r.status_code == 400

--- a/tests/fusion/test_responses.py
+++ b/tests/fusion/test_responses.py
@@ -19,7 +19,7 @@ from fusion.responses import (
     Problem,
     Response,
     Unauthorized,
-    ValidationError,
+    ValidationProblem,
 )
 
 # ---------------------------------------------------------------------------
@@ -163,15 +163,15 @@ async def test_custom_problem_subclass():
 async def test_validation_error_includes_field_errors():
     from fusion.responses import FieldError
 
-    r = ValidationError(
+    r = ValidationProblem(
         detail="failed",
-        errors=[FieldError(field="email", message="invalid")],
+        errors=[FieldError(field="email", location="body", message="invalid")],
     )
     _, _, body = await _call(r)
     import json
 
     data = json.loads(body)
-    assert data["errors"] == [{"field": "email", "message": "invalid"}]
+    assert data["errors"] == [{"field": "email", "location": "body", "message": "invalid"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Introduces `ValidationException` (Python exception) and `ValidationProblem` (HTTP response) for structured, RFC-9457-compliant error responses
- `Request.instance()` collects **all** field-level validation errors across headers, query params, path params, cookies, and body before responding — no more fail-on-first
- `RequestBodyResolver` uses a two-pass decode strategy: fast-path typed decode first, then per-field `msgspec.convert` to collect granular errors without parsing error message strings
- All resolvers now carry a `location` ClassVar (`"header"`, `"query"`, `"path"`, `"cookie"`, `"body"`) for accurate error attribution
- Renamed `ValidationError` → `ValidationProblem` to eliminate confusion with `msgspec.ValidationError`
- `context.body()` now raises `ValidationException` (not `ValueError`) for oversized bodies so the router handles it correctly

## Test plan

- [ ] `test_headers_with_missing_header` — 400 with `errors` list containing both missing fields
- [ ] `test_optional_header_resolves_to_none_when_missing` — 200 with `null` value
- [ ] `test_cookie_resolver` — 200 with cookie value
- [ ] `test_path_param_resolver_with_none_value` — `msgspec.ValidationError` raised
- [ ] `test_validation_error_with_field_errors` — 400 with structured `errors` array
- [ ] `test_custom_problem_subclass` — 409 with custom problem type
- [ ] All 113 existing tests pass: `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)