### PR TITLE
feat: explicit on= join columns using field descriptors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
     rev: v0.15.11
   - repo: local
     hooks:
+      - id: ruff-format-check
+        name: ruff-format-check
+        entry: ruff format --check src/ tests/
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: pyright
         name: pyright
         entry: pyright src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: "3.12"
+  python: "3.14"
 repos:
   - hooks:
       - args:
@@ -26,12 +26,18 @@ repos:
         id: ruff
       - id: ruff-format
     repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.15.11
   - repo: local
     hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright src/
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: pytest-check
         name: pytest-check
-        entry: pytest --cov
+        entry: pytest --cov=src/fusion --cov-report=term-missing
         language: system
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,10 @@ uv sync --extra dev          # install all deps
 uv run pytest                # tests + doctests + coverage
 uv run pytest --cov=src/fusion --cov-report=term-missing  # with missing lines
 
-.venv/bin/python -m ruff check src/   # lint
-.venv/bin/python -m ruff format src/  # format
-.venv/bin/python -m pyright src/      # type-check
+.venv/bin/python -m ruff check src/                  # lint
+.venv/bin/python -m ruff format src/ tests/          # format (auto-fix)
+.venv/bin/python -m ruff format --check src/ tests/  # format (check only, what CI runs)
+.venv/bin/python -m pyright src/                     # type-check
 ```
 
 ## Before pushing to GitHub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# fusion
+
+ASGI web framework with built-in DI, OpenAPI generation, ORM, and MCP support.
+
+## Stack
+
+- Python 3.14, [msgspec](https://github.com/jcrist/msgspec), [pypika](https://github.com/kayak/pypika), asyncpg
+- Tests: pytest + pytest-cov (coverage must stay ≥ 98%)
+- Lint: ruff, pyright
+
+## Commands
+
+```bash
+uv sync --extra dev          # install all deps
+
+uv run pytest                # tests + doctests + coverage
+uv run pytest --cov=src/fusion --cov-report=term-missing  # with missing lines
+
+.venv/bin/python -m ruff check src/   # lint
+.venv/bin/python -m ruff format src/  # format
+.venv/bin/python -m pyright src/      # type-check
+```
+
+## Before pushing to GitHub
+
+Run pre-commit checks:
+
+```bash
+uv run pre-commit run --all-files
+```
+
+Or install the hooks once so they run automatically on every commit:
+
+```bash
+uv run pre-commit install --hook-type commit-msg --hook-type pre-commit
+```
+
+## Conventions
+
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `test:`, `bump:`).
+- ORM queries are lazy — `.build()` returns `(sql, params)`, nothing hits the DB until `.fetch()`.
+- `Exp` is an escape hatch for raw SQL — never interpolate user input into it.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -434,6 +434,66 @@ After a join, WHERE conditions on joined table columns are automatically qualifi
 
 ```
 
+#### Explicit join columns
+
+When no `ForeignKey` exists between two models, pass `on=(LeftModel.col, RightModel.col)` using the field descriptors directly:
+
+```python
+>>> class Employee(Model):
+...     id: int | None = None
+...     department_id: int
+...     name: str
+
+>>> class Department(Model):
+...     id: int | None = None
+...     name: str
+
+>>> sql, params = Employee.select().join(Department, on=(Employee.department_id, Department.id)).build()
+>>> sql
+'SELECT * FROM "employees" JOIN "departments" ON "employees"."department_id"="departments"."id"'
+
+```
+
+`how` works the same way:
+
+```python
+>>> sql, params = Employee.select().join(Department, on=(Employee.department_id, Department.id), how="left").build()
+>>> sql
+'SELECT * FROM "employees" LEFT JOIN "departments" ON "employees"."department_id"="departments"."id"'
+
+```
+
+For joins on multiple columns, pass a list of pairs — each pair is AND'd in the ON clause:
+
+```python
+>>> class Product(Model):
+...     id: int | None = None
+...     sku: str
+...     region: str
+
+>>> class Price(Model):
+...     id: int | None = None
+...     sku: str
+...     region: str
+...     amount: int
+
+>>> sql, params = Product.select().join(
+...     Price, on=[(Product.sku, Price.sku), (Product.region, Price.region)]
+... ).build()
+>>> sql
+'SELECT * FROM "products" JOIN "prices" ON "products"."sku"="prices"."sku" AND "products"."region"="prices"."region"'
+
+```
+
+Explicit `on` also overrides FK inference when you need a non-standard join column. Here `Post` has a `ForeignKey("author_id", Author)`, but we join on a different column pair instead:
+
+```python
+>>> sql, params = Post.select().join(Author, on=(Post.title, Author.email)).build()
+>>> sql
+'SELECT * FROM "posts" JOIN "authors" ON "posts"."title"="authors"."email"'
+
+```
+
 ### INSERT
 
 `INSERT` always appends `RETURNING *`. The database fills in `id` and any DB-sentinel defaults; the returned rows are fully populated model instances.

--- a/src/fusion/orm/query.py
+++ b/src/fusion/orm/query.py
@@ -15,6 +15,8 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 _SENTINEL_TYPES = (_DbNow, _DbUuid)
 
+_OnArg = tuple[typing.Any, typing.Any] | list[tuple[typing.Any, typing.Any]] | None
+
 _JOIN_METHODS = {
     "inner": "join",
     "left": "left_join",
@@ -108,7 +110,7 @@ class SelectQuery:
         self._columns = columns
         self._wheres: list[Q | Condition] = []
         self._raw_wheres: list[str] = []
-        self._joins: list[tuple[type, dict[str, str] | None, str]] = []
+        self._joins: list[tuple[type, _OnArg, str]] = []
         self._order: list[tuple[str, bool]] = []
         self._limit_val: int | None = None
         self._offset_val: int | None = None
@@ -131,9 +133,7 @@ class SelectQuery:
             q._raw_wheres.append(exp.sql)
         return q
 
-    def join(
-        self, model: type[Model], *, on: dict[str, str] | None = None, how: str = "inner"
-    ) -> SelectQuery:
+    def join(self, model: type[Model], *, on: _OnArg = None, how: str = "inner") -> SelectQuery:
         q = SelectQuery.__new__(SelectQuery)
         q.__dict__ = {**self.__dict__, "_joins": list(self._joins)}
         q._joins.append((model, on, how))
@@ -166,9 +166,11 @@ class SelectQuery:
         else:
             q = PostgreSQLQuery.from_(table).select("*")
 
-        for join_model, _on, how in self._joins:
+        for join_model, on_arg, how in self._joins:
             join_table = _make_table(join_model)
-            on_clause = _infer_join_on(self._model, join_model, table, join_table)
+            on_clause = _build_explicit_on(on_arg, table, join_table) or _infer_join_on(
+                self._model, join_model, table, join_table
+            )
             join_fn = getattr(q, _JOIN_METHODS.get(how, "join"))
             if on_clause is not None:
                 q = join_fn(join_table).on(on_clause)
@@ -359,6 +361,23 @@ class DeleteQuery:
 def _make_table(model: type[Model]) -> Table:
     schema = getattr(model, "__schema__", None)
     return Table(model.__table_name__, schema=schema)
+
+
+def _build_explicit_on(
+    on_arg: _OnArg,
+    source_table: Table,
+    target_table: Table,
+) -> pypika.Criterion | None:
+    if on_arg is None:
+        return None
+    pairs: list[tuple[typing.Any, typing.Any]] = (
+        on_arg if isinstance(on_arg, list) else [on_arg]
+    )
+    criterion: pypika.Criterion | None = None
+    for left_col, right_col in pairs:
+        pair_criterion = source_table[left_col.name] == target_table[right_col.name]
+        criterion = pair_criterion if criterion is None else criterion & pair_criterion
+    return criterion
 
 
 def _infer_join_on(

--- a/src/fusion/orm/query.py
+++ b/src/fusion/orm/query.py
@@ -370,9 +370,7 @@ def _build_explicit_on(
 ) -> pypika.Criterion | None:
     if on_arg is None:
         return None
-    pairs: list[tuple[typing.Any, typing.Any]] = (
-        on_arg if isinstance(on_arg, list) else [on_arg]
-    )
+    pairs: list[tuple[typing.Any, typing.Any]] = on_arg if isinstance(on_arg, list) else [on_arg]
     criterion: pypika.Criterion | None = None
     for left_col, right_col in pairs:
         pair_criterion = source_table[left_col.name] == target_table[right_col.name]

--- a/tests/fusion/orm/test_query.py
+++ b/tests/fusion/orm/test_query.py
@@ -263,9 +263,9 @@ def test_select_join_explicit_on_overrides_fk():
 
 
 def test_select_join_explicit_on_multi_pair():
-    sql, params = Post.select().join(
-        User, on=[(Post.user_id, User.id), (Post.title, User.username)]
-    ).build()
+    sql, params = (
+        Post.select().join(User, on=[(Post.user_id, User.id), (Post.title, User.username)]).build()
+    )
     assert (
         sql
         == 'SELECT * FROM "posts" JOIN "users" ON "posts"."user_id"="users"."id" AND "posts"."title"="users"."username"'

--- a/tests/fusion/orm/test_query.py
+++ b/tests/fusion/orm/test_query.py
@@ -250,6 +250,35 @@ def test_select_join_with_where():
     assert params == [1]
 
 
+def test_select_join_explicit_on_single_pair_no_fk():
+    sql, params = Post.select().join(User, on=(Post.user_id, User.id)).build()
+    assert sql == 'SELECT * FROM "posts" JOIN "users" ON "posts"."user_id"="users"."id"'
+    assert params == []
+
+
+def test_select_join_explicit_on_overrides_fk():
+    sql, params = Article.select().join(Author, on=(Article.title, Author.email)).build()
+    assert sql == 'SELECT * FROM "articles" JOIN "authors" ON "articles"."title"="authors"."email"'
+    assert params == []
+
+
+def test_select_join_explicit_on_multi_pair():
+    sql, params = Post.select().join(
+        User, on=[(Post.user_id, User.id), (Post.title, User.username)]
+    ).build()
+    assert (
+        sql
+        == 'SELECT * FROM "posts" JOIN "users" ON "posts"."user_id"="users"."id" AND "posts"."title"="users"."username"'
+    )
+    assert params == []
+
+
+def test_select_join_explicit_on_left_join():
+    sql, params = Post.select().join(User, on=(Post.user_id, User.id), how="left").build()
+    assert sql == 'SELECT * FROM "posts" LEFT JOIN "users" ON "posts"."user_id"="users"."id"'
+    assert params == []
+
+
 # ---------------------------------------------------------------------------
 # SELECT — schema-qualified table
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `on=(LeftModel.col, RightModel.col)` to `.join()` for joining models without a `ForeignKey` constraint
- List of pairs `on=[(col1, col2), (col3, col4)]` ANDs multiple conditions in the ON clause
- Explicit `on` takes priority over FK inference when both are present
- Introduces `_OnArg` type alias to keep the join storage type tidy for pyright
- Updates `ruff-pre-commit` rev to `v0.15.11`, fixes `default_language_version` to `3.14`, adds `pyright` pre-commit hook
- Adds `CLAUDE.md` with project conventions and pre-commit reminder
- Adds docs examples and doctests to `docs/orm.md`

## Test plan

- [x] `uv run pytest` — all tests + doctests pass, coverage ≥ 98%
- [x] `ruff check src/` — clean
- [x] `pyright src/` — 0 errors
- [x] `uv run pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)