### PR TITLE
feat: fix prefetch duplicate join and add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,23 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
 
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      POSTGRES_DSN: postgresql://postgres:postgres@localhost:5432/test
+
     steps:
       - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,4 @@ uv run pre-commit install --hook-type commit-msg --hook-type pre-commit
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `test:`, `bump:`).
 - ORM queries are lazy — `.build()` returns `(sql, params)`, nothing hits the DB until `.fetch()`.
 - `Exp` is an escape hatch for raw SQL — never interpolate user input into it.
+- ORM query tests must assert the **full SQL string** — never use `in sql`, `sql.count(...)`, or substring checks. Always `assert sql == "..."` with the complete expected query.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -547,7 +547,7 @@ Required (non-optional) relationships work the same way but the FK column is non
 ```python
 >>> sql, _ = Article.select().prefetch(Author).build()
 >>> sql
-'SELECT * FROM "articles" LEFT JOIN "authors" ON "articles"."author_id"="authors"."id"'
+'SELECT "articles"."id","articles"."title","articles"."author_id","authors"."id" "author__id","authors"."name" "author__name" FROM "articles" LEFT JOIN "authors" ON "articles"."author_id"="authors"."id"'
 
 ```
 
@@ -575,7 +575,7 @@ When the related model uses a custom table name via `__table__`, `.prefetch()` u
 
 >>> sql, _ = Comment.select().prefetch(LegacyUser).build()
 >>> sql
-'SELECT * FROM "comments" LEFT JOIN "tbl_users" ON "comments"."author_id"="tbl_users"."id"'
+'SELECT "comments"."id","comments"."body","comments"."author_id","tbl_users"."id" "author__id","tbl_users"."name" "author__name" FROM "comments" LEFT JOIN "tbl_users" ON "comments"."author_id"="tbl_users"."id"'
 
 ```
 
@@ -594,7 +594,7 @@ Multiple relationships are prefetched in a single query:
 
 >>> sql, _ = TaggedArticle.select().prefetch(Author, Tag).build()
 >>> sql
-'SELECT * FROM "tagged_articles" LEFT JOIN "authors" ON "tagged_articles"."author_id"="authors"."id" LEFT JOIN "tags" ON "tagged_articles"."tag_id"="tags"."id"'
+'SELECT "tagged_articles"."id","tagged_articles"."title","tagged_articles"."author_id","tagged_articles"."tag_id","authors"."id" "author__id","authors"."name" "author__name","tags"."id" "tag__id","tags"."name" "tag__name" FROM "tagged_articles" LEFT JOIN "authors" ON "tagged_articles"."author_id"="authors"."id" LEFT JOIN "tags" ON "tagged_articles"."tag_id"="tags"."id"'
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ addopts = [
     "--tb=long",
 ]
 testpaths = ["tests", "src/fusion", "docs"]
+markers = [
+    "integration: marks tests as integration tests (require Docker)",
+]
 
 [tool.coverage.run]
 branch = true
@@ -110,3 +113,8 @@ exclude = ["**/__init__.py", "**/__pycache__"]
 
 [tool.uv.sources]
 typedprotocol = { git = "https://github.com/okanakbulut/typedprotocol.git", rev = "main" }
+
+[dependency-groups]
+dev = [
+    "asyncpg>=0.31.0",
+]

--- a/src/fusion/orm/query.py
+++ b/src/fusion/orm/query.py
@@ -197,6 +197,16 @@ class SelectQuery:
 
         if self._columns:
             q = PostgreSQLQuery.from_(table).select(*[table[c] for c in self._columns])
+        elif self._prefetches:
+            # pypika silently drops additional column selects when SELECT * is used,
+            # so list the main table's columns explicitly whenever prefetches are present.
+            rel_fields = getattr(self._model, "__relationship_fields__", frozenset())
+            main_cols = [
+                table[f.name]
+                for f in msgspec.structs.fields(self._model)  # type: ignore[arg-type]
+                if f.name not in rel_fields
+            ]
+            q = PostgreSQLQuery.from_(table).select(*main_cols)
         else:
             q = PostgreSQLQuery.from_(table).select("*")
 
@@ -213,11 +223,13 @@ class SelectQuery:
             else:
                 q = join_fn(join_table).on(LiteralValue("true"))  # type: ignore[arg-type]
 
+        already_joined = {jm for jm, _, _, _ in self._joins}
         for prefetch_model in self._prefetches:
             rel_field, fk_constraint = _find_prefetch_relation(self._model, prefetch_model)
             join_table = _make_table(prefetch_model)
-            on_clause = table[fk_constraint.column] == join_table[fk_constraint.target_column]
-            q = q.left_join(join_table).on(on_clause)
+            if prefetch_model not in already_joined:
+                on_clause = table[fk_constraint.column] == join_table[fk_constraint.target_column]
+                q = q.left_join(join_table).on(on_clause)
             for sf in msgspec.structs.fields(prefetch_model):  # type: ignore[arg-type]
                 q = q.select(join_table[sf.name].as_(f"{rel_field}__{sf.name}"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if not os.environ.get("POSTGRES_DSN"):
+        skip = pytest.mark.skip(reason="set POSTGRES_DSN to run integration tests")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip)

--- a/tests/fusion/orm/integration/conftest.py
+++ b/tests/fusion/orm/integration/conftest.py
@@ -1,0 +1,29 @@
+import os
+import typing
+
+import asyncpg
+import pytest_asyncio
+
+from fusion.orm.migration.apply import to_ddl
+from fusion.orm.migration.diff import diff
+from fusion.orm.migration.snapshot import serialize
+from fusion.orm.model import Model
+
+
+@pytest_asyncio.fixture
+async def pg_conn() -> typing.AsyncGenerator[asyncpg.Connection]:
+    conn = await asyncpg.connect(os.environ["POSTGRES_DSN"])
+    yield conn
+    await conn.close()
+
+
+async def apply_schema(conn: asyncpg.Connection, models: list[type[Model]]) -> None:
+    snapshot = serialize(models)
+    statements = to_ddl(diff({}, snapshot))
+    for stmt in statements:
+        await conn.execute(stmt)
+
+
+async def drop_tables(conn: asyncpg.Connection, models: list[type[Model]]) -> None:
+    for model in reversed(models):
+        await conn.execute(f'DROP TABLE IF EXISTS "{model.__table_name__}" CASCADE')

--- a/tests/fusion/orm/integration/test_orm_integration.py
+++ b/tests/fusion/orm/integration/test_orm_integration.py
@@ -1,0 +1,131 @@
+"""Integration tests: migration → insert → join → prefetch against a real Postgres instance."""
+
+import asyncpg
+import pytest
+
+from fusion.orm import Model
+from fusion.orm.migration.apply import to_ddl
+from fusion.orm.migration.diff import diff
+from fusion.orm.migration.snapshot import serialize
+
+from .conftest import apply_schema, drop_tables
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Models used across all integration tests
+# ---------------------------------------------------------------------------
+
+
+class Org(Model):
+    id: int | None = None
+    name: str
+
+
+class User(Model):
+    id: int | None = None
+    email: str
+    org: Org | None = None
+
+
+_MODELS = [Org, User]
+
+
+# ---------------------------------------------------------------------------
+# Bullet 1 — migration creates the expected tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_tables(pg_conn: asyncpg.Connection):
+    await drop_tables(pg_conn, _MODELS)
+    await apply_schema(pg_conn, _MODELS)
+
+    tables = await pg_conn.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename"
+    )
+    table_names = {r["tablename"] for r in tables}
+    assert "orgs" in table_names
+    assert "users" in table_names
+
+
+# ---------------------------------------------------------------------------
+# Bullet 2 — insert returns the persisted row with server-assigned id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_returns_row(pg_conn: asyncpg.Connection):
+    await drop_tables(pg_conn, _MODELS)
+    await apply_schema(pg_conn, _MODELS)
+
+    results = await Org.insert().values(Org(name="Acme")).fetch(pg_conn)
+
+    assert len(results) == 1
+    assert results[0].name == "Acme"
+    assert results[0].id is not None
+
+
+# ---------------------------------------------------------------------------
+# Bullet 3 — join filters rows via the joined table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_join_filters_by_joined_table(pg_conn: asyncpg.Connection):
+    await drop_tables(pg_conn, _MODELS)
+    await apply_schema(pg_conn, _MODELS)
+
+    (acme,) = await Org.insert().values(Org(name="Acme")).fetch(pg_conn)
+    (other,) = await Org.insert().values(Org(name="Other")).fetch(pg_conn)
+    await User.insert().values(User(email="alice@acme.com", org_id=acme.id)).fetch(pg_conn)
+    await User.insert().values(User(email="bob@other.com", org_id=other.id)).fetch(pg_conn)
+
+    results = await User.select().join(Org).where(org__name="Acme").fetch(pg_conn)
+
+    assert len(results) == 1
+    assert results[0].email == "alice@acme.com"
+
+
+# ---------------------------------------------------------------------------
+# Bullet 4 — prefetch hydrates the relationship on each result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefetch_hydrates_org_on_user(pg_conn: asyncpg.Connection):
+    await drop_tables(pg_conn, _MODELS)
+    await apply_schema(pg_conn, _MODELS)
+
+    (acme,) = await Org.insert().values(Org(name="Acme")).fetch(pg_conn)
+    await User.insert().values(User(email="alice@acme.com", org_id=acme.id)).fetch(pg_conn)
+
+    results = await User.select().prefetch(Org).fetch(pg_conn)
+
+    assert len(results) == 1
+    assert isinstance(results[0].org, Org)
+    assert results[0].org.name == "Acme"
+
+
+# ---------------------------------------------------------------------------
+# Bullet 5 — join + prefetch on the same model: no DuplicateAliasError,
+#             relationship hydrated, join filter applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_join_and_prefetch_same_model(pg_conn: asyncpg.Connection):
+    await drop_tables(pg_conn, _MODELS)
+    await apply_schema(pg_conn, _MODELS)
+
+    (acme,) = await Org.insert().values(Org(name="Acme")).fetch(pg_conn)
+    (other,) = await Org.insert().values(Org(name="Other")).fetch(pg_conn)
+    await User.insert().values(User(email="alice@acme.com", org_id=acme.id)).fetch(pg_conn)
+    await User.insert().values(User(email="bob@other.com", org_id=other.id)).fetch(pg_conn)
+
+    results = await User.select().join(Org).prefetch(Org).where(org__name="Acme").fetch(pg_conn)
+
+    assert len(results) == 1
+    assert results[0].email == "alice@acme.com"
+    assert isinstance(results[0].org, Org)
+    assert results[0].org.name == "Acme"

--- a/tests/fusion/orm/test_relationships.py
+++ b/tests/fusion/orm/test_relationships.py
@@ -26,9 +26,20 @@ def test_relationship_field_injects_fk_column():
 
 def test_prefetch_generates_left_join():
     sql, _ = Article.select().prefetch(Author).build()
-    assert (
-        sql
-        == 'SELECT * FROM "articles" LEFT JOIN "authors" ON "articles"."author_id"="authors"."id"'
+    assert sql == (
+        'SELECT "articles"."id","articles"."title","articles"."author_id",'
+        '"authors"."id" "author__id","authors"."name" "author__name"'
+        ' FROM "articles" LEFT JOIN "authors" ON "articles"."author_id"="authors"."id"'
+    )
+
+
+def test_join_and_prefetch_same_model_no_duplicate_join():
+    """Explicit .join() + .prefetch() on the same model must not emit the table twice."""
+    sql, _ = Article.select().join(Author).prefetch(Author).build()
+    assert sql == (
+        'SELECT "articles"."id","articles"."title","articles"."author_id",'
+        '"authors"."id" "author__id","authors"."name" "author__name"'
+        ' FROM "articles" JOIN "authors" ON "articles"."author_id"="authors"."id"'
     )
 
 
@@ -62,9 +73,13 @@ class TaggedArticle(Model):
 
 def test_multi_prefetch_generates_two_joins():
     sql, _ = TaggedArticle.select().prefetch(Author, Tag).build()
-    assert (
-        sql
-        == 'SELECT * FROM "tagged_articles" LEFT JOIN "authors" ON "tagged_articles"."author_id"="authors"."id" LEFT JOIN "tags" ON "tagged_articles"."tag_id"="tags"."id"'
+    assert sql == (
+        'SELECT "tagged_articles"."id","tagged_articles"."title","tagged_articles"."author_id","tagged_articles"."tag_id",'
+        '"authors"."id" "author__id","authors"."name" "author__name",'
+        '"tags"."id" "tag__id","tags"."name" "tag__name"'
+        ' FROM "tagged_articles"'
+        ' LEFT JOIN "authors" ON "tagged_articles"."author_id"="authors"."id"'
+        ' LEFT JOIN "tags" ON "tagged_articles"."tag_id"="tags"."id"'
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,30 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -224,6 +248,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "asyncpg" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = "==4.13.10" },
@@ -242,6 +271,9 @@ requires-dist = [
     { name = "typedprotocol", git = "https://github.com/okanakbulut/typedprotocol.git?rev=main" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "asyncpg", specifier = ">=0.31.0" }]
 
 [[package]]
 name = "h11"


### PR DESCRIPTION
## Summary

- **Fix `DuplicateAliasError`** when `.join(Model)` and `.prefetch(Model)` target the same model — prefetch now skips emitting a second JOIN if the table is already joined
- **Fix `SELECT *` + prefetch incompatibility** — pypika silently drops additional column selects when `SELECT *` is active; switched to explicit column listing when prefetches are present
- **Add Postgres integration tests** covering migration, insert, join filtering, prefetch hydration, and join+prefetch together on the same model
- **Remove `testcontainers`** — replaced with a `POSTGRES_DSN` env var; integration tests skip locally unless the var is set, CI uses GitHub Actions native `services: postgres:18-alpine`

## Test plan

- [ ] `uv run pytest` — 342 unit tests pass, 5 integration tests skipped (no `POSTGRES_DSN`)
- [ ] `POSTGRES_DSN=postgresql://... uv run pytest` — all 347 tests pass
- [ ] CI runs all tests via `services: postgres:18-alpine` with `POSTGRES_DSN` set at the job level

🤖 Generated with [Claude Code](https://claude.com/claude-code)